### PR TITLE
Add ServiceOffer Entity with CRUD Implementation

### DIFF
--- a/Applications/DTOs/ServiceOffer/ServiceOfferRequest.cs
+++ b/Applications/DTOs/ServiceOffer/ServiceOfferRequest.cs
@@ -1,0 +1,12 @@
+using Domain.Enums;
+
+namespace Applications.DTOs.ServiceOffer;
+
+public record struct ServiceOfferRequest
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public decimal? Fees { get; set; }
+    public bool? IsActive { get; set; }
+}

--- a/Applications/DTOs/ServiceOffer/ServiceOfferResponse.cs
+++ b/Applications/DTOs/ServiceOffer/ServiceOfferResponse.cs
@@ -1,0 +1,9 @@
+namespace Applications.DTOs.ServiceOffer;
+
+public record struct ServiceOfferResponse
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public decimal Fees { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Applications/DependencyInjection.cs
+++ b/Applications/DependencyInjection.cs
@@ -18,7 +18,8 @@ namespace Applications
             services.AddScoped<IStudentService, StudentService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IProfessorService, ProfessorService>();
-
+            services.AddScoped<IServiceOfferService, ServiceOfferService>();
+            
             return services;
         }
     }

--- a/Applications/Interfaces/Repositories/IServiceOfferRepository.cs
+++ b/Applications/Interfaces/Repositories/IServiceOfferRepository.cs
@@ -1,0 +1,10 @@
+using Applications.Interfaces.Base;
+using Domain.Entities;
+using Domain.Enums;
+
+namespace Applications.Interfaces.Repositories;
+
+public interface IServiceOfferRepository : IGenericRepository<ServiceOffer>
+{
+    Task<bool> DoesExistAsync(string name);
+}

--- a/Applications/Interfaces/Services/IServiceOfferService.cs
+++ b/Applications/Interfaces/Services/IServiceOfferService.cs
@@ -1,0 +1,13 @@
+using Applications.DTOs.ServiceOffer;
+using Applications.Shared;
+
+namespace Applications.Interfaces.Services;
+
+public interface IServiceOfferService
+{
+    Task<Result<IReadOnlyCollection<ServiceOfferResponse>>> GetListAsync();
+    Task<Result<ServiceOfferResponse>> GetByIdAsync(int id);
+    Task<Result<ServiceOfferResponse>> AddAsync(ServiceOfferRequest? request);
+    Task<Result> UpdateAsync(int id, ServiceOfferRequest? request);
+    Task<Result> DeleteAsync(int id);
+}

--- a/Applications/Mappers/MappingProfile.cs
+++ b/Applications/Mappers/MappingProfile.cs
@@ -11,6 +11,7 @@ namespace Applications.Mappers
             ApplyPersonMapping();
             ApplyUserMapping();
             ApplyProfessorMapping();
+            ApplyServiceOfferMapping();
         }
 
         //Method signatures
@@ -19,6 +20,7 @@ namespace Applications.Mappers
         partial void ApplyPersonMapping();
         partial void ApplyUserMapping();
         partial void ApplyProfessorMapping();
+        partial void ApplyServiceOfferMapping();
     }
 
   

--- a/Applications/Mappers/ServiceOffer/ApplyServiceOfferMapping.cs
+++ b/Applications/Mappers/ServiceOffer/ApplyServiceOfferMapping.cs
@@ -1,0 +1,20 @@
+using Applications.DTOs.ServiceOffer;
+using AutoMapper;
+using Domain.Entities;
+
+namespace Applications.Mappers;
+
+public partial class MappingProfile : Profile
+{
+    partial void ApplyServiceOfferMapping()
+    {
+        CreateMap<ServiceOffer, ServiceOfferResponse>().ReverseMap();
+        
+        CreateMap<ServiceOfferRequest, ServiceOffer>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.Fees, opt => opt.Condition(src => src.Fees.HasValue))
+            .ForMember(dest => dest.Name, opt => opt.Condition(src => src.Name != null))
+            .ForMember(dest => dest.Description, opt => opt.Condition(src => src.Description != null))
+            .ForMember(dest => dest.IsActive, opt => opt.Condition(src => src.IsActive.HasValue));
+    }
+}

--- a/Applications/Services/ServiceOfferService.cs
+++ b/Applications/Services/ServiceOfferService.cs
@@ -1,0 +1,132 @@
+using Applications.DTOs.ServiceOffer;
+using Applications.Interfaces.Repositories;
+using Applications.Interfaces.Services;
+using Applications.Shared;
+using Applications.Utilities;
+using AutoMapper;
+using Domain.Entities;
+using Domain.Enums;
+
+namespace Applications.Services;
+
+public class ServiceOfferService : IServiceOfferService
+{
+    private readonly IServiceOfferRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly IMyLogger _logger;
+    
+    public ServiceOfferService(IServiceOfferRepository repository, IMapper mapper, IMyLogger logger)
+    {
+        _repository = repository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+    
+    public async Task<Result<IReadOnlyCollection<ServiceOfferResponse>>> GetListAsync()
+    {
+        try
+        {
+            var offers = await _repository.GetListAsync();
+            if (!offers.Any())
+            {
+                return Result<IReadOnlyCollection<ServiceOfferResponse>>.Failure(
+                    "No service offers found", ErrorType.NotFound);
+            }
+
+            var response = _mapper.Map<IReadOnlyCollection<ServiceOfferResponse>>(offers);
+            return Result<IReadOnlyCollection<ServiceOfferResponse>>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Database error retrieving all service offers", ex);
+            return Result<IReadOnlyCollection<ServiceOfferResponse>>
+                .Failure("Failed to retrieve service offers due to a system error", ErrorType.InternalServerError);
+        }
+    }
+    
+    public async Task<Result<ServiceOfferResponse>> GetByIdAsync(int id)
+    {
+        if (id <= 0)
+            return Result<ServiceOfferResponse>.Failure("Invalid service offer ID provided", ErrorType.BadRequest);
+
+        try
+        {
+            var offer = await _repository.GetByIdAsync(id);
+            if (offer == null)
+                return Result<ServiceOfferResponse>.Failure("Service offer not found with the specified ID", ErrorType.NotFound);
+
+            var response = _mapper.Map<ServiceOfferResponse>(offer);
+            return Result<ServiceOfferResponse>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Database error retrieving service offer", ex, new { id });
+            return Result<ServiceOfferResponse>.Failure("Failed to retrieve service offer due to a system error", ErrorType.InternalServerError);
+        }
+    }
+
+    public async Task<Result<ServiceOfferResponse>> AddAsync(ServiceOfferRequest? request)
+    {
+        if (request == null)
+            return Result<ServiceOfferResponse>.Failure("Service offer information is required", ErrorType.BadRequest);
+
+        var isExist = await _repository.DoesExistAsync(request.Value.Name ?? string.Empty);
+        if (isExist)
+            return Result<ServiceOfferResponse>.Failure("Service offer already exists", ErrorType.Conflict);
+
+        var offer = _mapper.Map<ServiceOffer>(request);
+        try
+        {
+            int id = await _repository.AddAsync(offer);
+            if (id <= 0)
+                return Result<ServiceOfferResponse>.Failure("Failed to create new service offer", ErrorType.BadRequest);
+
+            var response = _mapper.Map<ServiceOfferResponse>(offer);
+            return Result<ServiceOfferResponse>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Database error adding new service offer", ex, new { request });
+            return Result<ServiceOfferResponse>.Failure("Failed to create service offer due to a system error", ErrorType.InternalServerError);
+        }
+    }
+
+    public async Task<Result> UpdateAsync(int id, ServiceOfferRequest? request)
+    {
+        if (request == null)
+            return Result.Failure("Service offer information is required for update", ErrorType.BadRequest);
+
+        var service = await _repository.GetByIdAsync(id);
+        if (service == null)
+            return Result.Failure("Service offer not found", ErrorType.NotFound);
+
+        _mapper.Map(request.Value, service);
+        try
+        {
+            bool isUpdated = await _repository.UpdateAsync(service);
+            return !isUpdated ? Result.Failure("Failed to update service offer", ErrorType.BadRequest) : Result.Success;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Database error updating service offer", ex, new { request });
+            return Result.Failure("Failed to update service offer due to a system error", ErrorType.InternalServerError);
+        }
+    }
+
+    public async Task<Result> DeleteAsync(int id)
+    {
+        if (id <= 0)
+            return Result.Failure("Invalid service offer ID provided", ErrorType.BadRequest);
+
+        try
+        {
+            bool isDeleted = await _repository.DeleteAsync(id);
+            return !isDeleted ? Result.Failure("Service offer not found", ErrorType.NotFound) : Result.Success;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Database error deleting service offer", ex, new { id });
+            return Result.Failure("Failed to delete service offer due to a system error", ErrorType.InternalServerError);
+        }
+    }
+}

--- a/Domain/Entities/ServiceOffer.cs
+++ b/Domain/Entities/ServiceOffer.cs
@@ -1,0 +1,16 @@
+using Domain.Enums;
+using Domain.Interfaces;
+
+namespace Domain.Entities;
+
+/// <summary>
+/// University service definition with fees for the 8 core services offered
+/// </summary>
+public class ServiceOffer : IEntity
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public string? Description { get; set; }
+    public decimal Fees { get; set; }
+    public bool IsActive { get; set; }
+}

--- a/Infrastructure/Data/AppDbContext.cs
+++ b/Infrastructure/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ namespace Infrastructure.Data
         public DbSet<Country> Countries { get; set; }  
         public DbSet<User> Users { get; set; }
         public DbSet<Professor> Professors { get; set; }
+        public DbSet<ServiceOffer> ServiceOffers { get; set; }
 
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 

--- a/Infrastructure/Data/Configuration/ServiceOfferConfig.cs
+++ b/Infrastructure/Data/Configuration/ServiceOfferConfig.cs
@@ -1,0 +1,42 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Data.Configuration;
+
+public class ServiceOfferConfig : IEntityTypeConfiguration<ServiceOffer>
+{
+    public void Configure(EntityTypeBuilder<ServiceOffer> builder)
+    {
+        builder.ToTable("service_offers");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Id)
+            .HasColumnName("id")
+            .ValueGeneratedOnAdd();
+
+        builder.Property(s => s.Name)
+            .HasColumnName("name")
+            .HasColumnType("varchar")
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(s => s.Description)
+            .HasColumnType("varchar")
+            .HasColumnName("description")
+            .HasMaxLength(500);
+
+        builder.Property(s => s.Fees)
+            .HasColumnName("fees")
+            .HasColumnType("decimal(8,2)");
+
+        builder.Property(s => s.IsActive)
+            .HasColumnName("is_active")
+            .HasDefaultValue(true);
+
+        builder.HasIndex(s => s.Name)
+            .HasDatabaseName("ix_services_name")
+            .IsUnique();
+    }
+}

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -22,6 +22,7 @@ namespace Infrastructure
             services.AddScoped<IStudentRepository, StudentRepository>();
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IProfessorRepository, ProfessorRepository>();
+            services.AddScoped<IServiceOfferRepository, ServiceOfferRepository>();
 
             return services;
         }

--- a/Infrastructure/Migrations/20250619185417_AddServiceOffers.Designer.cs
+++ b/Infrastructure/Migrations/20250619185417_AddServiceOffers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619185417_AddServiceOffers")]
+    partial class AddServiceOffers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20250619185417_AddServiceOffers.cs
+++ b/Infrastructure/Migrations/20250619185417_AddServiceOffers.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServiceOffers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "service_offers",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "varchar", maxLength: 100, nullable: false),
+                    description = table.Column<string>(type: "varchar", maxLength: 500, nullable: true),
+                    fees = table.Column<decimal>(type: "numeric(8,2)", nullable: false),
+                    is_active = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_service_offers", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_services_name",
+                table: "service_offers",
+                column: "name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "service_offers");
+        }
+    }
+}

--- a/Infrastructure/Repositories/ServiceOfferRepository.cs
+++ b/Infrastructure/Repositories/ServiceOfferRepository.cs
@@ -1,0 +1,16 @@
+using Applications.Interfaces.Repositories;
+using Domain.Entities;
+using Domain.Enums;
+using Infrastructure.Data;
+using Infrastructure.Repositories.Base;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories;
+
+public class ServiceOfferRepository(AppDbContext context) : GenericRepository<ServiceOffer>(context), IServiceOfferRepository
+{
+    public async Task<bool> DoesExistAsync(string name)
+    {
+        return await _context.ServiceOffers.AnyAsync(x => x.Name == name);
+    }
+}

--- a/Presentation/Controllers/ServiceOffersController.cs
+++ b/Presentation/Controllers/ServiceOffersController.cs
@@ -1,0 +1,72 @@
+using Applications.DTOs.ServiceOffer;
+using Applications.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
+using Presentation.Controllers.ResultExtension;
+
+namespace Presentation.Controllers;
+
+[ApiController]
+[Route("api/serviceOffers")]
+public class ServiceOffersController(IServiceOfferService service) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IEnumerable<ServiceOfferResponse>>> GetList()
+    {
+        var response = await service.GetListAsync();
+        return !response.IsSuccess ? response.HandleResult() : Ok(response.Value);
+    }
+
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<ServiceOfferResponse>> GetById(int id)
+    {
+        var response = await service.GetByIdAsync(id);
+        return !response.IsSuccess ? response.HandleResult() : Ok(response.Value);
+    }
+
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<ServiceOfferResponse>> Create(ServiceOfferRequest? request)
+    {
+        var response = await service.AddAsync(request);
+        if (!response.IsSuccess)
+            return response.HandleResult();
+
+        return CreatedAtAction(nameof(GetById), new { id = response.Value.Id }, response.Value);
+    }
+
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Delete(int id)
+    {
+        var response = await service.DeleteAsync(id);
+        return !response.IsSuccess ? response.HandleResult() : NoContent();
+    }
+
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Update(int id, ServiceOfferRequest? request)
+    {
+        var response = await service.UpdateAsync(id, request);
+        return !response.IsSuccess ? response.HandleResult() : NoContent();
+    }
+}


### PR DESCRIPTION
# Summary  
This PR adds a new `ServiceOffer` entity to the system with complete CRUD operations, following the established patterns used for other entities.

## Changes Made  
### 🗄️ Database & Entity  
- Added `ServiceOffer` entity class representing university service definitions  
- Created and applied EF Core migration for `ServiceOffer` table  

### 🔧 Repository & Service Layer  
- Implemented `IServiceOfferRepository` interface inheriting from generic repository  
- Implemented `ServiceOfferRepository` class with service-specific operations  
- Implemented `IServiceOfferService` interface for business logic  
- Implemented `ServiceOfferService` class with CRUD operations  

### 📝 DTOs & Mapping  
- Added ServiceOffer DTOs:  
  - `ServiceOfferRequest` - for creating/updating offers  
  - `ServiceOfferResponse` - for API responses  
- Registered AutoMapper configuration for ServiceOffer entity mappings  

## Technical Details  
- Follows existing repository pattern and dependency injection setup  
- Maintains consistency with other entity implementations  
- All new services properly registered in DI container  
- Includes proper validation for fees and service details  

## Testing  
- Migration applied successfully  
- ServiceOffer CRUD operations working as expected  
- Fee validation working correctly  
- Active/inactive status functioning properly  
- AutoMapper mappings configured correctly  